### PR TITLE
Restrict access to edit and update other user information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'rack_session_access'
   gem 'selenium-webdriver', '~> 4.0.0.alpha6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,9 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack_session_access (0.2.0)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
     rails (6.0.3.2)
       actioncable (= 6.0.3.2)
       actionmailbox (= 6.0.3.2)
@@ -258,6 +261,7 @@ DEPENDENCIES
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)
+  rack_session_access
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-i18n (~> 6.0.0)
   rspec-rails (~> 4.0.1)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :check_login, only: %i[show edit update]
+  before_action :check_user, only: %i[edit update]
+
   def new
     @user = User.new
   end
@@ -49,5 +52,18 @@ class UsersController < ApplicationController
       :password,
       :password_confirmation
     )
+  end
+
+  # before action
+
+  # Check user is logged in
+  def check_login
+    redirect_to login_path unless logged_in?
+  end
+
+  # Check user is self
+  def check_user
+    @user = User.find(params[:id])
+    redirect_to root_path unless current_user?(@user)
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,12 +12,12 @@ module SessionsHelper
   # Return the logged in user
   def current_user
     if (user_id = session[:user_id])
-      User.find_by(id: user_id)
+      @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
       if user&.authenticated?(cookies[:remember_token])
         log_in user
-        user
+        @current_user = user
       end
     end
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -22,6 +22,11 @@ module SessionsHelper
     end
   end
 
+  # Returns true if the given user is logged in
+  def current_user?(user)
+    user && user == current_user
+  end
+
   # Log out the current user
   def log_out
     forget(current_user)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Access to rack session
+  config.middleware.use RackSessionAccess::Middleware
+
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe SessionsHelper, type: :helper do
     end
   end
 
+  describe '#current_user?(user)' do
+    context 'when the given user is logged in' do
+      before { log_in(test1) }
+
+      it 'return true' do
+        expect(current_user?(test1)).to eq true
+      end
+    end
+
+    context 'when the given user is not logged in' do
+      it 'return false' do
+        expect(current_user?(test1)).to eq false
+      end
+    end
+  end
+
   describe '#log_out' do
     context 'when the user is logged in' do
       before { remember test1 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,8 @@ RSpec.configure do |config|
     end
   end
 
+  config.include TestHelper
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'rack_session_access/capybara'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -44,53 +47,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -1,0 +1,6 @@
+module TestHelper
+  # Log in with the given user
+  def log_in(user)
+    page.set_rack_session(user_id: user.id)
+  end
+end

--- a/spec/system/users/update_spec.rb
+++ b/spec/system/users/update_spec.rb
@@ -1,37 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe 'UsersUpdate', type: :system do
-  before do
-    @test1 = create(:test1)
-    visit edit_user_path(@test1)
-  end
+  before { @test1 = create(:test1) }
 
-  context 'when user information is valid' do
-    it 'update a user information' do
-      fill_in 'ユーザー名（50文字以内）', with: 'test1-update'
-      fill_in 'メールアドレス', with: 'test1-update@gmail.com'
-      fill_in 'パスワード（6文字以上）', with: 'foobar'
-      fill_in '確認用パスワード', with: 'foobar'
-      click_button '登録する'
-      @test1.reload
-      expect(@test1.name).to eq 'test1-update'
-      expect(@test1.email).to eq 'test1-update@gmail.com'
-      expect(@test1.authenticate('foobar')).to be_truthy
+  subject { page }
+
+  context 'when the user is logged in' do
+    before do
+      log_in(@test1)
+      visit edit_user_path(@test1)
+    end
+
+    context 'when user information is valid' do
+      it 'update a user information' do
+        fill_in 'ユーザー名（50文字以内）', with: 'test1-update'
+        fill_in 'メールアドレス', with: 'test1-update@gmail.com'
+        fill_in 'パスワード（6文字以上）', with: 'foobar'
+        fill_in '確認用パスワード', with: 'foobar'
+        click_button '登録する'
+        @test1.reload
+        expect(@test1.name).to eq 'test1-update'
+        expect(@test1.email).to eq 'test1-update@gmail.com'
+        expect(@test1.authenticate('foobar')).to be_truthy
+      end
+    end
+
+    context 'when user information is invalid' do
+      it 'do not update a user information' do
+        fill_in 'ユーザー名（50文字以内）', with: ''
+        fill_in 'メールアドレス', with: 'testgmail.com'
+        fill_in 'パスワード（6文字以上）', with: 'hoge'
+        fill_in '確認用パスワード', with: 'hoge'
+        click_button '登録する'
+        @test1.reload
+        expect(@test1.name).to eq 'test1'
+        expect(@test1.email).to eq 'test1@gmail.com'
+        expect(@test1.authenticate('password')).to be_truthy
+        is_expected.to have_css '.error-messages'
+      end
     end
   end
 
-  context 'when user information is invalid' do
-    it 'do not update a user information' do
-      fill_in 'ユーザー名（50文字以内）', with: ''
-      fill_in 'メールアドレス', with: 'testgmail.com'
-      fill_in 'パスワード（6文字以上）', with: 'hoge'
-      fill_in '確認用パスワード', with: 'hoge'
-      click_button '登録する'
-      @test1.reload
-      expect(@test1.name).to eq 'test1'
-      expect(@test1.email).to eq 'test1@gmail.com'
-      expect(@test1.authenticate('password')).to be_truthy
-      expect(page).to have_css '.error-messages'
+  context 'when the user is not logged in' do
+    it 'cannot access edit page' do
+      visit edit_user_path(@test1)
+      is_expected.to have_current_path login_path
     end
   end
 end


### PR DESCRIPTION
・他のユーザーのユーザー情報の編集・更新をできないようにしました。
・sessions_helper.rbのcurrent_userヘルパーメソッドを修正して、ログインユーザーが存在する時、DBへの無駄なアクセスを行わないようにしました。
・sessions_helper_spec.rbにcurrent_user?(user)ヘルパーメソッドのテストを追加しました。
・spec/system/users/update_spec.rbを修正しました。