### PR TITLE
Cannot edit and update and delete other users posts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+
+  private
+
+  # before action
+
+  # Check user is logged in
+  def check_login
+    redirect_to login_path unless logged_in?
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
-  before_action :check_login, only: %i[new create show edit update delete]
-  before_action :check_user, only: %i[edit update delete]
+  before_action :check_login, only: %i[new create show edit update destroy]
+  before_action :check_user, only: %i[edit update destroy]
 
   def new
     @post = current_user.posts.build

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,7 @@
 class PostsController < ApplicationController
+  before_action :check_login, only: %i[new create show edit update delete]
+  before_action :check_user, only: %i[edit update delete]
+
   def new
     @post = current_user.posts.build
   end
@@ -20,12 +23,9 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
-  def edit
-    @post = Post.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @post = Post.find(params[:id])
     if @post.update(post_params)
       redirect_to @post
     else
@@ -34,7 +34,6 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post = Post.find(params[:id])
     @post.destroy
     redirect_to root_path
   end
@@ -46,5 +45,13 @@ class PostsController < ApplicationController
       :title,
       :content
     )
+  end
+
+  # before action
+
+  # Check user is self
+  def check_user
+    @post = Post.find(params[:id])
+    redirect_to root_path unless current_user?(@post.user)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,11 +56,6 @@ class UsersController < ApplicationController
 
   # before action
 
-  # Check user is logged in
-  def check_login
-    redirect_to login_path unless logged_in?
-  end
-
   # Check user is self
   def check_user
     @user = User.find(params[:id])

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,6 @@
     <li>
       <p><%= post.user.name %></p>
       <p><%= link_to post.title, post_path(post.id) %></p>
-      <%= link_to '削除する', post, method: :delete, data: { confirm: '本当に削除しますか？' } %>
     </li>
   <% end %>
 </ul>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,3 +5,7 @@
       <p><%= @post.content %></p>
     </li>
 </ul>
+
+<% if current_user?(@post.user) %>
+  <%= link_to '削除する', @post, method: :delete, data: { confirm: '本当に削除しますか？' } %>
+<% end %>


### PR DESCRIPTION
・他のユーザーの投稿の編集・更新・削除をできないようにしました。
・未ログイン状態の時は、投稿の作成、詳細ページの表示、投稿の編集・更新・削除をできないようにしました。