### PR TITLE
Change the domain of email address to example.com

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
   end
 
   def guest
-    @user = User.find_by(email: 'guest@gmail.com')
+    @user = User.find_by(email: 'guest@example.com')
     log_in @user
     flash[:success] = 'ログインしました！'
     redirect_to @user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,21 +1,21 @@
 FactoryBot.define do
   factory :test1, class: User do
     name { 'test1' }
-    email { 'test1@gmail.com' }
+    email { 'test1@example.com' }
     password { 'password' }
     password_confirmation { 'password' }
   end
 
   factory :test2, class: User do
     name { 'test2' }
-    email { 'test2@gmail.com' }
+    email { 'test2@example.com' }
     password { 'password' }
     password_confirmation { 'password' }
   end
 
   factory :guest, class: User do
     name { 'guest' }
-    email { 'guest@gmail.com' }
+    email { 'guest@example.com' }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe User, type: :model do
       end
 
       context 'when email is over 256 characters' do
-        before { test1.email = 'a' * 247 + '@gmail.com' }
+        before { test1.email = 'a' * 247 + '@example.com' }
 
         it 'return false' do
           expect(test1.valid?).to eq false
@@ -63,11 +63,11 @@ RSpec.describe User, type: :model do
       context 'when email is an invalid format' do
         it 'return false' do
           [
-            'user＠gmail.com',
-            'usergmail.com',
-            'user@gmail..com',
-            'user@.gmail.com',
-            'user@gmail.com-'
+            'user＠example.com',
+            'userexample.com',
+            'user@example..com',
+            'user@.example.com',
+            'user@example.com-'
           ].each do |invalid_email|
             test1.email = invalid_email
             expect(test1.valid?).to eq false

--- a/spec/system/users/login_spec.rb
+++ b/spec/system/users/login_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'UsersLogin', type: :system do
 
   context 'when login information is incorrect' do
     it 'not log in' do
-      fill_in 'メールアドレス', with: 'incorrect@gmail.com'
+      fill_in 'メールアドレス', with: 'incorrect@example.com'
       fill_in 'パスワード', with: 'password'
       click_button 'ログインする'
       is_expected.to have_css '.danger-message'

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'UsersSignup', type: :system do
   context 'when user information is valid' do
     it 'signup a user' do
       fill_in 'ユーザー名（50文字以内）', with: 'test'
-      fill_in 'メールアドレス', with: 'test@gmail.com'
+      fill_in 'メールアドレス', with: 'test@example.com'
       fill_in 'パスワード（6文字以上）', with: 'password'
       fill_in '確認用パスワード', with: 'password'
       expect { click_button '登録する' }.to change(User, :count).by(1)
@@ -16,7 +16,7 @@ RSpec.describe 'UsersSignup', type: :system do
   context 'when user information is invalid' do
     it 'do not signup a user' do
       fill_in 'ユーザー名（50文字以内）', with: ''
-      fill_in 'メールアドレス', with: 'testgmail.com'
+      fill_in 'メールアドレス', with: 'testexample.com'
       fill_in 'パスワード（6文字以上）', with: 'password'
       fill_in '確認用パスワード', with: 'pasword'
       expect { click_button '登録する' }.to change(User, :count).by(0)

--- a/spec/system/users/update_spec.rb
+++ b/spec/system/users/update_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe 'UsersUpdate', type: :system do
     context 'when user information is valid' do
       it 'update a user information' do
         fill_in 'ユーザー名（50文字以内）', with: 'test1-update'
-        fill_in 'メールアドレス', with: 'test1-update@gmail.com'
+        fill_in 'メールアドレス', with: 'test1-update@example.com'
         fill_in 'パスワード（6文字以上）', with: 'foobar'
         fill_in '確認用パスワード', with: 'foobar'
         click_button '登録する'
         @test1.reload
         expect(@test1.name).to eq 'test1-update'
-        expect(@test1.email).to eq 'test1-update@gmail.com'
+        expect(@test1.email).to eq 'test1-update@example.com'
         expect(@test1.authenticate('foobar')).to be_truthy
       end
     end
@@ -28,13 +28,13 @@ RSpec.describe 'UsersUpdate', type: :system do
     context 'when user information is invalid' do
       it 'do not update a user information' do
         fill_in 'ユーザー名（50文字以内）', with: ''
-        fill_in 'メールアドレス', with: 'testgmail.com'
+        fill_in 'メールアドレス', with: 'testexample.com'
         fill_in 'パスワード（6文字以上）', with: 'hoge'
         fill_in '確認用パスワード', with: 'hoge'
         click_button '登録する'
         @test1.reload
         expect(@test1.name).to eq 'test1'
-        expect(@test1.email).to eq 'test1@gmail.com'
+        expect(@test1.email).to eq 'test1@example.com'
         expect(@test1.authenticate('password')).to be_truthy
         is_expected.to have_css '.error-messages'
       end


### PR DESCRIPTION
サンプルユーザーのメールアドレスのドメインをgmail.comからexample.comに変更しました。